### PR TITLE
Made boss health HUD elements respect convar

### DIFF
--- a/scripting/dtk/events.sp
+++ b/scripting/dtk/events.sp
@@ -76,7 +76,7 @@ void Event_RoundRestart(Event event, const char[] name, bool dontBroadcast)
 	}
 	
 	// Hide Health Bar
-	SetHealthBar();
+	RefreshBossHealthHUD();
 	
 	// Begin Redistribution
 	SelectActivators();
@@ -396,7 +396,7 @@ Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadcast)
 	// Boss Health Bar
 	//if (g_ConVars[P_BossBar].BoolValue && victim == g_iBoss)
 	if (Player(victim).IsActivator)
-		SetHealthBar();
+		RefreshBossHealthHUD();
 }
 
 

--- a/scripting/dtk/forwards.sp
+++ b/scripting/dtk/forwards.sp
@@ -312,7 +312,7 @@ public void OnClientDisconnect(int client)
 	if (game.IsBossBarActive && client == g_iBoss)
 	{
 		g_iBoss = -1;
-		SetHealthBar();
+		RefreshBossHealthHUD();
 	}
 	*/
 }

--- a/scripting/dtk/functions.sp
+++ b/scripting/dtk/functions.sp
@@ -1737,14 +1737,15 @@ stock void DBReset(int client)
 #define USE_BOSS_BAR
 
 /**
- * Set the percentage of the boss health bar.
+ * Refresh boss health HUD display elements
  *
- * @param	int	Health
- * @param	int	Max health
  * @noreturn
  */
-void SetHealthBar()
+void RefreshBossHealthHUD()
 {
+	if (!g_ConVars[P_BossBar].BoolValue)
+		return;
+		
 	/*
 		Priority
 		--------
@@ -1879,7 +1880,8 @@ stock void HealthText(const char[] string = "", any ...)
 // TODO Use this to update activator health values in the array without updating the bars
 
 /**
- * Update the boss health bar in response to damage to a client
+ * Update stored health and max health values of client Activator in dynamic array,
+ * then cause boss health HUD to update to reflect changes.
  *
  * @param		int		Client index
  * @noreturn
@@ -1911,7 +1913,7 @@ void UpdateHealthBar(int client)
 		}
 	}
 	
-	SetHealthBar();
+	RefreshBossHealthHUD();
 }
 
 

--- a/scripting/dtk/hooks.sp
+++ b/scripting/dtk/hooks.sp
@@ -62,7 +62,7 @@ void Hook_HealthEnts(const char[] output, int caller, int activator, float delay
 		
 		//int percent = RoundToNearest((val / max) * 255);
 		//SetEntProp(healthbar.Index, Prop_Send, "m_iBossHealthPercentageByte", percent);
-		SetHealthBar();
+		RefreshBossHealthHUD();
 	}
 	
 /*	// Fired From logic_relay TODO Replace with logic_case


### PR DESCRIPTION
The boss health HUD elements were still being displayed in reaction to some events even though the system cvar was disabled.