### PR TITLE
Better Map Detection

### DIFF
--- a/scripting/dtk.sp
+++ b/scripting/dtk.sp
@@ -140,10 +140,12 @@ public void OnPluginEnd() {
 public void OnConfigsExecuted() {
 	// auto enable
 	if (g_ConVars[P_AutoEnable].BoolValue) {
-		char mapname[32];
+		char mapname[96]; // 96 = max mapname size
+		char displayname[64]; // 64 = max clean mapname size
 		GetCurrentMap(mapname, sizeof(mapname));
+		GetMapDisplayName(mapname, displayname, sizeof(displayname)); // "workshop/mapname.ugc123456789" -> "mapname"
 
-		if (StrContains(mapname, "dr_", false) == 0 || StrContains(mapname, "deathrun_", false) == 0)
+		if (StrContains(displayname, "dr_", false) == 0 || StrContains(displayname, "deathrun_", false) == 0 || StrContains(displayname, "vsh_dr_", false) == 0)
 			g_ConVars[P_Enabled].SetBool(true);
 	}
 }

--- a/scripting/dtk.sp
+++ b/scripting/dtk.sp
@@ -143,7 +143,7 @@ public void OnConfigsExecuted() {
 		char mapname[32];
 		GetCurrentMap(mapname, sizeof(mapname));
 
-		if (StrContains(mapname, "dr_", false) != -1 || StrContains(mapname, "deathrun_", false) != -1)
+		if (StrContains(mapname, "dr_", false) == 0 || StrContains(mapname, "deathrun_", false) == 0)
 			g_ConVars[P_Enabled].SetBool(true);
 	}
 }


### PR DESCRIPTION
I fixed array sizes for map names, and also made use of [`GetMapDisplayName()`](https://www.sourcemod.net/new-api/halflife/GetMapDisplayName) to account for workshop maps.

And also:
- `StrContains(...) != -1` means "check for substring at any position".
  - This is bad because, for example, maps like [`rdr_dustbowl`](https://steamcommunity.com/sharedfiles/filedetails/?id=3659831025) get detected as Deathrun due to `dr_` being at position `1` in the chars array.
- `StrContains(...) == 0` means "check for substring at position `0`".
  - *This* is what we want, because if `dr_` or `deathrun_` isn't exactly at the beginning, then it won't be falsely detected as a "Deathrun map".